### PR TITLE
Remove duplicate status field in store schema

### DIFF
--- a/models/storeModel.js
+++ b/models/storeModel.js
@@ -34,12 +34,6 @@ const storeSchema = new mongoose.Schema(
     supportingPhone: { type: String },
     phoneNumber: { type: String },
 
-    status: {
-      type: String,
-      enum: ["active", "inactive"],
-      default: "active",
-    },
-
     // Rider-specific fields
     riderDetails: {
       vehicleType: {


### PR DESCRIPTION
## Summary
- remove duplicate `status` field in store schema to avoid redundant definitions

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68bc3bf76830832d9bd9a09e41556611