### PR TITLE
Implement store dashboard summary and add tests

### DIFF
--- a/controllers/storeControllers/storeController.js
+++ b/controllers/storeControllers/storeController.js
@@ -15,45 +15,56 @@ export const getStoreDetails = async (req, res) => {
     //   return res.status(403).json({ message: "Unauthorized access" });
     // }
 
-    // Aggregate summary data
-    const summary = await Transaction.aggregate([
-      { $match: { storeId: new mongoose.Types.ObjectId(storeId) } }, // Filter by store ID
+    // Aggregate transaction summary data
+    const transactionSummary = await Transaction.aggregate([
+      { $match: { storeId: new mongoose.Types.ObjectId(storeId) } },
       {
         $group: {
           _id: null,
-          totalTransactions: { $sum: 1 }, // Count total transactions matching the store ID
-          totalStockItems: { $sum: { $sum: "$products.quantity" } }, // Total quantity of items sold
-          totalItemsLeftInStock: { $sum: 0 }, // Placeholder (requires a Product model or other logic)
-          totalItemsOutOfStock: { $sum: 0 }, // Placeholder (requires a Product model or other logic)
-          totalSoldItems: { $sum: { $sum: "$products.quantity" } }, // Total sold items
-          totalOrderSales: { $sum: "$totalAmount" }, // Total sales amount
-          totalFeesCharged: { $sum: "$fee" }, // Total fees collected
-
+          totalTransactions: { $sum: 1 },
+          totalStockItems: { $sum: { $sum: "$products.quantity" } },
+          totalSoldItems: { $sum: { $sum: "$products.quantity" } },
+          totalOrderSales: { $sum: "$totalAmount" },
+          totalFeesCharged: { $sum: "$fee" },
           completedOrders: {
-            $sum: {
-              $cond: [{ $eq: ["$status", "completed"] }, 1, 0],
-            },
+            $sum: { $cond: [{ $eq: ["$status", "completed"] }, 1, 0] },
           },
           pendingOrders: {
-            $sum: {
-              $cond: [{ $eq: ["$status", "pending"] }, 1, 0],
-            },
+            $sum: { $cond: [{ $eq: ["$status", "pending"] }, 1, 0] },
           },
           failedOrders: {
-            $sum: {
-              $cond: [{ $eq: ["$status", "failed"] }, 1, 0],
-            },
+            $sum: { $cond: [{ $eq: ["$status", "failed"] }, 1, 0] },
+          },
+        },
+      },
+    ]);
+
+    // Aggregate product inventory data
+    const inventorySummary = await Product.aggregate([
+      { $match: { storeId: new mongoose.Types.ObjectId(storeId) } },
+      {
+        $group: {
+          _id: null,
+          totalItemsLeftInStock: { $sum: "$quantity" },
+          totalItemsOutOfStock: {
+            $sum: { $cond: [{ $eq: ["$quantity", 0] }, 1, 0] },
           },
         },
       },
     ]);
 
     const storeProfile = await Store.findById(storeId).select("-password");
-    // const transactions = await Transaction.find({storeId: new mongoose.Types.ObjectId(storeId)});
+    const transactions = await Transaction.find({
+      storeId: new mongoose.Types.ObjectId(storeId),
+    });
+
+    const { _id: _tId, ...tSummary } = transactionSummary[0] || {};
+    const { _id: _iId, ...iSummary } = inventorySummary[0] || {};
+
     res.json({
-      // summary: summary[0] || {},
+      summary: { ...tSummary, ...iSummary },
       storeProfile: storeProfile || {},
-      // transactions: transactions || [], // Placeholder (requires additional logic to fetch transaction details)
+      transactions: transactions || [],
     });
   } catch (error) {
     console.error(error);

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "main": "index.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1",
+    "test": "node --test tests",
     "dev": "nodemon index.js"
   },
   "keywords": [],

--- a/tests/storeController.test.js
+++ b/tests/storeController.test.js
@@ -1,0 +1,59 @@
+import test from 'node:test';
+import assert from 'node:assert';
+import mongoose from 'mongoose';
+
+import { getStoreDetails } from '../controllers/storeControllers/storeController.js';
+import Transaction from '../models/transactionModel.js';
+import Product from '../models/productModel.js';
+import Store from '../models/storeModel.js';
+
+test('getStoreDetails returns expected dashboard structure', async () => {
+  const storeId = new mongoose.Types.ObjectId();
+
+  // Mock transaction aggregation
+  Transaction.aggregate = async () => [
+    {
+      _id: null,
+      totalTransactions: 2,
+      totalStockItems: 5,
+      totalSoldItems: 5,
+      totalOrderSales: 200,
+      totalFeesCharged: 20,
+      completedOrders: 2,
+      pendingOrders: 0,
+      failedOrders: 0,
+    },
+  ];
+
+  // Mock product aggregation
+  Product.aggregate = async () => [
+    {
+      _id: null,
+      totalItemsLeftInStock: 10,
+      totalItemsOutOfStock: 1,
+    },
+  ];
+
+  // Mock store profile lookup
+  Store.findById = () => ({
+    select: async () => ({ _id: storeId, name: 'Test Store' }),
+  });
+
+  // Mock transaction list
+  Transaction.find = async () => [{ _id: new mongoose.Types.ObjectId(), amount: 200 }];
+
+  const req = { userId: storeId.toString(), userType: 'Store' };
+  let jsonResponse;
+  const res = { json: (data) => { jsonResponse = data; } };
+
+  await getStoreDetails(req, res);
+
+  assert.ok(jsonResponse.summary, 'summary should be present');
+  assert.ok(jsonResponse.storeProfile, 'storeProfile should be present');
+  assert.ok(Array.isArray(jsonResponse.transactions), 'transactions should be an array');
+
+  assert.strictEqual(jsonResponse.summary.totalTransactions, 2);
+  assert.strictEqual(jsonResponse.summary.totalItemsLeftInStock, 10);
+  assert.strictEqual(jsonResponse.summary.totalItemsOutOfStock, 1);
+});
+


### PR DESCRIPTION
## Summary
- expose store summary and transactions in `getStoreDetails`
- compute stock counts from product inventory
- add unit test for store dashboard structure

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bc3c08717c832d8fd7aec0c888cd39