### PR TITLE
Enforce store user access on store routes

### DIFF
--- a/controllers/storeControllers/storeController.js
+++ b/controllers/storeControllers/storeController.js
@@ -9,11 +9,9 @@ import Store from "../../models/storeModel.js";
 export const getStoreDetails = async (req, res) => {
   try {
     const { userId: storeId, userType } = req;
-    console.log(storeId);
-
-    // if (userType !== "Store") {
-    //   return res.status(403).json({ message: "Unauthorized access" });
-    // }
+    if (userType !== "Store") {
+      return res.status(403).json({ message: "Unauthorized access" });
+    }
 
     // Aggregate summary data
     const summary = await Transaction.aggregate([
@@ -64,10 +62,12 @@ export const getStoreDetails = async (req, res) => {
 };
 // Get Store Dashboard Data
 export const updateStoreProfile = async (req, res) => {
-  console.log("I Got Here");
-
   try {
     const { userId: storeId, userType } = req;
+    if (userType !== "Store") {
+      return res.status(403).json({ message: "Forbidden" });
+    }
+
     const {
       phoneNumber,
       password,
@@ -81,10 +81,6 @@ export const updateStoreProfile = async (req, res) => {
       lga,
       profilePhoto,
     } = req.body;
-
-    // if (userType !== "Store") {
-    //   return res.status(403).json({ message: "Forbidden" });
-    // }
 
     const storeProfile = await Store.findById(storeId);
 
@@ -112,7 +108,6 @@ export const updateStoreProfile = async (req, res) => {
       storeProfile.password = hashedPassword;
     }
     const updatedStoreProfile = await storeProfile.save();
-    console.log(updatedStoreProfile);
 
     res.status(200).json({
       message: "Store profile updated successfully",
@@ -128,19 +123,19 @@ export const updateStoreProfile = async (req, res) => {
 
 export const changeStorePassword = async (req, res) => {
   try {
-    const { userId: storeId } = req;
+    const { userId: storeId, userType } = req;
     const { oldPassword, newPassword } = req.body;
+    if (userType !== "Store") {
+      return res
+        .status(403)
+        .json({ message: "Unauthorized: Not a store user" });
+    }
 
     // Check if the user is authenticated
     const storeUser = await Store.findById(storeId);
-
-    // if (storeUser.userType !== "Store") {
-    //   return res
-    //     .status(403)
-    //     .json({ message: "Unauthorized: Not a store user" });
-    // }
-
-    console.log(storeUser);
+    if (!storeUser) {
+      return res.status(404).json({ message: "Store not found" });
+    }
 
     // Check if the old password matches the stored hash
     const isMatch = await bcrypt.compare(oldPassword, storeUser.password);
@@ -163,7 +158,11 @@ export const changeStorePassword = async (req, res) => {
 export const updateStoreNotifications = async (req, res) => {
   try {
     const { notificationPreferences } = req.body;
-    const { userId: storeId } = req;
+    const { userId: storeId, userType } = req;
+
+    if (userType !== "Store") {
+      return res.status(403).json({ message: "Unauthorized access" });
+    }
 
     if (!notificationPreferences) {
       return res.status(400).json({ message: "Invalid request data." });
@@ -188,7 +187,10 @@ export const updateStoreNotifications = async (req, res) => {
 
 export const getStoreProducts = async (req, res) => {
   try {
-    const { userId: storeId } = req;
+    const { userId: storeId, userType } = req;
+    if (userType !== "Store") {
+      return res.status(403).json({ message: "Unauthorized access" });
+    }
     const products = await Product.find({
       storeId: new mongoose.Types.ObjectId(storeId),
     });

--- a/middlewares/verifyToken.js
+++ b/middlewares/verifyToken.js
@@ -2,7 +2,6 @@ import jwt from "jsonwebtoken";
 import User from "../models/userModel.js";
 
 export const verifyToken = (req, res, next) => {
-  console.log("Verifying token...", req); // Log to check if this middleware is hit
   let token;
   if (
     req.headers.authorization &&
@@ -10,20 +9,16 @@ export const verifyToken = (req, res, next) => {
   ) {
     token = req.headers.authorization.split(" ")[1];
   }
-  console.log("Token:", token); // Log the token for debugging
   if (!token) {
     return res.status(401).send("Not authorized, no token");
   }
   try {
     const decoded = jwt.verify(token, process.env.JWT_SECRET);
-    console.log(decoded);
-
-    // Add the decoded user ID to the request object for further use in routes or middleware
+    // Add the decoded user details to the request object for further use in routes or middleware
     req.userId = decoded.id;
-    // req.userType = decoded.userType;
+    req.userType = decoded.userType;
     next();
   } catch (error) {
-    console.error("Token verification failed:", error); // Log the error for debugging
     return res.status(401).send(`${error} Not authorized, token failed`);
   }
 };

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "main": "index.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1",
+    "test": "node --test tests/*.test.js",
     "dev": "nodemon index.js"
   },
   "keywords": [],

--- a/tests/storeAccess.test.js
+++ b/tests/storeAccess.test.js
@@ -1,0 +1,42 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import express from 'express';
+import jwt from 'jsonwebtoken';
+import storeRoutes from '../routes/storeRoutes.js';
+
+// Ensure JWT secret for tests
+process.env.JWT_SECRET = 'testsecret';
+
+function createApp() {
+  const app = express();
+  app.use(express.json());
+  app.use('/api/store', storeRoutes);
+  return app;
+}
+
+test('non-store user denied access to store details', async (t) => {
+  const app = createApp();
+  const server = app.listen(0);
+  t.after(() => server.close());
+  const token = jwt.sign({ id: 'user1', userType: 'Customer' }, process.env.JWT_SECRET);
+  const res = await fetch(`http://localhost:${server.address().port}/api/store/store-details`, {
+    headers: { Authorization: `Bearer ${token}` },
+  });
+  assert.strictEqual(res.status, 403);
+});
+
+test('non-store user cannot update store profile', async (t) => {
+  const app = createApp();
+  const server = app.listen(0);
+  t.after(() => server.close());
+  const token = jwt.sign({ id: 'user1', userType: 'Customer' }, process.env.JWT_SECRET);
+  const res = await fetch(`http://localhost:${server.address().port}/api/store/update-profile`, {
+    method: 'PUT',
+    headers: {
+      Authorization: `Bearer ${token}`,
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({}),
+  });
+  assert.strictEqual(res.status, 403);
+});


### PR DESCRIPTION
## Summary
- remove debug logs and attach `userType` in token verification middleware
- restrict store controllers to store accounts only
- add tests verifying non-store users cannot access store-only endpoints

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bc3c0d8ff8832db92fd1ec2b353323