### PR TITLE
Refactor store handling to use dedicated model

### DIFF
--- a/controllers/AdminControllers/dashboardController.js
+++ b/controllers/AdminControllers/dashboardController.js
@@ -61,7 +61,7 @@ export const getTopVisitedStores = async (req, res) => {
       { $sort: { totalOrders: -1 } },
       {
         $lookup: {
-          from: "users",
+          from: "stores",
           localField: "_id",
           foreignField: "_id",
           as: "storeDetails",

--- a/controllers/authController.js
+++ b/controllers/authController.js
@@ -38,6 +38,12 @@ export const signup = async (req, res) => {
   try {
     let { email, password, userType, ...rest } = req.body;
 
+    if (userType === "Store") {
+      return res
+        .status(400)
+        .json({ message: "Use /signup/store for store registration" });
+    }
+
     email = email.toLowerCase();
 
     // Check if email already exists
@@ -118,6 +124,12 @@ export const login = async (req, res) => {
   try {
     let { email, password, userType } = req.body;
     email = email.toLowerCase();
+
+    if (userType === "Store") {
+      return res
+        .status(400)
+        .json({ message: "Use /store/login for store accounts" });
+    }
 
     // Find user
     const user = await User.findOne({ email });

--- a/controllers/productsController.js
+++ b/controllers/productsController.js
@@ -1,5 +1,5 @@
 import Product from '../models/productModel.js';
-import User from '../models/userModel.js';
+import Store from '../models/storeModel.js';
 
 // POST /api/products → Create a new product (Admin/Store)
 export const createProduct = async (req, res) => {
@@ -10,16 +10,16 @@ export const createProduct = async (req, res) => {
       return res.status(400).json({ message: "Name, price, and quantity are required" });
     }
 
-    // Fetch the authenticated user from the database
-    const user = await User.findById(req.user.storeId); // Assuming the user ID is linked to the store
+    // Fetch the authenticated store from the database
+    const store = await Store.findById(req.userId);
 
-    // Ensure the user exists and is a store owner
-    if (user.userType !== "Store") {
+    // Ensure the store exists
+    if (!store) {
       return res.status(403).json({ message: "Unauthorized: Only store owners can create products" });
     }
 
-    // Extract store details (assuming store ID is linked to the user)
-    const storeId = user.storeId; // Use user's ID as storeId if no separate Store model
+    // Use store's ID as storeId
+    const storeId = req.userId;
 
     // Create the product with the storeId
     const newProduct = new Product({
@@ -119,16 +119,13 @@ export const createProducts = async (req, res) => {
       return res.status(400).json({ message: "Invalid input: Expecting an array of products" });
     }
 
-    // Fetch the authenticated user from the database
-    const user = await User.findById(storeId); // Assuming the user ID is linked to the store
+    // Fetch the authenticated store from the database
+    const store = await Store.findById(storeId);
 
-    // Ensure the user exists and is a store owner
-    if (!user || user.userType !== "Store") {
+    // Ensure the store exists
+    if (!store) {
       return res.status(403).json({ message: "Unauthorized: Only store owners can create products" });
     }
-
-    // Extract store details (assuming store ID is linked to the user)
-    // const storeId = user.storeId;
 
     // Validate each product object
     const validProducts = products.filter(product => 
@@ -214,9 +211,8 @@ export const getAllProductsForAdmin = async (req, res) => {
 
     const storeIds = [...new Set(products.map((p) => p.storeId?.toString()))].filter(Boolean);
 
-    const storeUsers = await User.find({
+    const storeUsers = await Store.find({
       _id: { $in: storeIds },
-      userType: "Store",
     }).select("_id name storeDetails");
 
     const storeMap = {};

--- a/controllers/storeControllers/storeController.js
+++ b/controllers/storeControllers/storeController.js
@@ -1,6 +1,5 @@
 import mongoose from "mongoose";
 import Transaction from "../../models/transactionModel.js";
-import User from "../../models/userModel.js";
 import bcrypt from "bcrypt";
 import Product from "../../models/productModel.js";
 import Store from "../../models/storeModel.js";

--- a/migrations/migrateStores.js
+++ b/migrations/migrateStores.js
@@ -1,0 +1,58 @@
+import mongoose from "mongoose";
+import dotenv from "dotenv";
+import User from "../models/userModel.js";
+import Store from "../models/storeModel.js";
+
+dotenv.config();
+
+const migrateStores = async () => {
+  try {
+    await mongoose.connect(process.env.MONGO_URI, {
+      dbName:
+        process.env.NODE_ENV === "development" ? "astercart-test" : "astercartdb",
+    });
+
+    const userStores = await User.find({ userType: "Store" });
+    for (const u of userStores) {
+      const storeData = {
+        name: u.name,
+        email: u.email,
+        location: u.location,
+        picture: u.picture,
+        emailVerificationCode: u.emailVerificationCode,
+        isEmailVerified: u.isEmailVerified,
+        password: u.password,
+        status: u.status,
+        storeDetails: u.storeDetails,
+        supportingEmail: u.supportingEmail,
+        supportingPhone: u.supportingPhone,
+        phoneNumber: u.phoneNumber,
+        riderDetails: u.riderDetails,
+        adminStatus: u.adminStatus,
+        inviteToken: u.inviteToken,
+        inviteTokenExpiry: u.inviteTokenExpiry,
+        onboarded: u.onboarded,
+        isBlocked: u.isBlocked,
+        isFlagged: u.isFlagged,
+        notificationPreferences: u.notificationPreferences,
+        otp: u.otp,
+        isOtpVerified: u.isOtpVerified,
+        resetToken: u.resetToken,
+        resetTokenExpiry: u.resetTokenExpiry,
+        createdAt: u.createdAt,
+        updatedAt: u.updatedAt,
+      };
+
+      await Store.create(storeData);
+      await User.deleteOne({ _id: u._id });
+    }
+
+    console.log(`Migrated ${userStores.length} stores`);
+    process.exit(0);
+  } catch (err) {
+    console.error("Migration failed:", err);
+    process.exit(1);
+  }
+};
+
+migrateStores();

--- a/models/userModel.js
+++ b/models/userModel.js
@@ -12,7 +12,7 @@ const userSchema = new mongoose.Schema(
     password: { type: String, required: true },
     userType: {
       type: String,
-      enum: ["Customer", "Rider", "Store", "Admin"],
+      enum: ["Customer", "Rider", "Admin"],
       required: true,
       index: true,
     },
@@ -43,24 +43,14 @@ const userSchema = new mongoose.Schema(
       select: false,
     },
     
-    // Store-specific fields
-    storeDetails: {
-      address: { type: String },
-      state: { type: String },
-      postalCode: { type: String },
-      lga: { type: String },
-    },
-    supportingEmail: { type: String },
-    supportingPhone: { type: String },
+    // Contact fields
     phoneNumber: { type: String },
 
     status: {
       type: String,
-      enum: ['active', 'inactive'],
-      default: 'active',
+      enum: ["active", "inactive"],
+      default: "active",
     },
-
-    
 
     // Rider-specific fields
     riderDetails: {

--- a/routes/authRoutes.js
+++ b/routes/authRoutes.js
@@ -15,6 +15,7 @@ import {
   customerSignupSchema,
   riderSignupSchema,
   loginSchema,
+  storeLoginSchema,
   adminSignupSchema,
   adminLoginSchema,
 } from "../utils/validations/userValidation.js";
@@ -70,7 +71,7 @@ router.post("/resend-verificationcode", resendVerificationCode);
 // Login route
 router.post("/login", validateRequest(loginSchema), login);
 // Login route
-router.post("/store/login", validateRequest(loginSchema), storeLogin);
+router.post("/store/login", validateRequest(storeLoginSchema), storeLogin);
 
 // private_data
 router.get("/private_data", verifyToken, privateData);

--- a/utils/validations/userValidation.js
+++ b/utils/validations/userValidation.js
@@ -37,7 +37,7 @@ export const riderSignupSchema = Joi.object({
 export const loginSchema = Joi.object({
   email: Joi.string().email().required(),
   password: Joi.string().min(6).required(),
-  userType: Joi.string().required(),
+  userType: Joi.string().valid("Customer", "Rider", "Admin").required(),
 });
 
 // ✅ Admin Signup Schema 
@@ -50,4 +50,9 @@ export const adminSignupSchema = Joi.object({
 export const adminLoginSchema = Joi.object({
   email: Joi.string().email().required(),
   password: Joi.string().min(6).required()
+});
+
+export const storeLoginSchema = Joi.object({
+  email: Joi.string().email().required(),
+  password: Joi.string().min(6).required(),
 });


### PR DESCRIPTION
## Summary
- Remove store-specific fields from `User` and rely on the `Store` model as the single source of truth
- Refactor admin and product flows to read and write store data via `Store`
- Add migration script and adjust auth validation/routes for store-only signup and login

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68bc3c22594c832db011313d4718131d