### PR TITLE
Handle discount and tax rate during product creation

### DIFF
--- a/controllers/productsController.js
+++ b/controllers/productsController.js
@@ -4,7 +4,16 @@ import Store from '../models/storeModel.js';
 // POST /api/products → Create a new product (Admin/Store)
 export const createProduct = async (req, res) => {
   try {
-    const { name, description, price, quantity, category, images = [] } = req.body;
+    const {
+      name,
+      description,
+      price,
+      quantity,
+      category,
+      images = [],
+      discount,
+      taxRate,
+    } = req.body;
 
     if (!name || price === undefined || quantity === undefined) {
       return res.status(400).json({ message: "Name, price, and quantity are required" });
@@ -31,6 +40,8 @@ export const createProduct = async (req, res) => {
       quantity,
       category,
       images,
+      discount,
+      taxRate,
       storeId, // Associate the product with the store
     });
 

--- a/tests/createProduct.test.js
+++ b/tests/createProduct.test.js
@@ -1,0 +1,49 @@
+import test from 'node:test';
+import assert from 'node:assert';
+import mongoose from 'mongoose';
+
+import { createProduct } from '../controllers/productsController.js';
+import Product from '../models/productModel.js';
+import Store from '../models/storeModel.js';
+
+test('createProduct persists discount and taxRate', async () => {
+  const storeId = new mongoose.Types.ObjectId();
+
+  // Mock store lookup
+  Store.findById = async () => ({ _id: storeId });
+
+  // Capture saved product
+  let savedProduct;
+  Product.prototype.save = async function () {
+    savedProduct = this;
+  };
+
+  const req = {
+    body: {
+      name: 'Test Product',
+      description: 'Desc',
+      price: 100,
+      quantity: 5,
+      category: 'Category',
+      images: [],
+      discount: 10,
+      taxRate: 5,
+    },
+    userId: storeId,
+  };
+
+  let statusCode;
+  const res = {
+    status(code) {
+      statusCode = code;
+      return this;
+    },
+    json() {},
+  };
+
+  await createProduct(req, res);
+
+  assert.strictEqual(statusCode, 201);
+  assert.strictEqual(savedProduct.discount, 10);
+  assert.strictEqual(savedProduct.taxRate, 5);
+});


### PR DESCRIPTION
## Summary
- include optional discount and taxRate fields in createProduct controller so values from UI are saved
- add unit test verifying createProduct persists discount and taxRate

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bccbf342f4832db000112164f30d54