### PR TITLE
Generate productId on product creation and add tests

### DIFF
--- a/controllers/productsController.js
+++ b/controllers/productsController.js
@@ -23,7 +23,14 @@ export const createProduct = async (req, res) => {
     const storeId = store._id;
 
 
-    // Create the product with the storeId
+    // Determine next sequential productId
+    const lastProduct = await Product.findOne().sort({ createdAt: -1 });
+    const lastProductId = lastProduct
+      ? parseInt(lastProduct.productId.substring(1))
+      : 0;
+    const productId = `P${String(lastProductId + 1).padStart(3, "0")}`;
+
+    // Create the product with the storeId and generated productId
     const newProduct = new Product({
       name,
       description,
@@ -32,6 +39,7 @@ export const createProduct = async (req, res) => {
       category,
       images,
       storeId, // Associate the product with the store
+      productId,
     });
 
     await newProduct.save();

--- a/tests/productController.test.js
+++ b/tests/productController.test.js
@@ -1,0 +1,70 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import mongoose from 'mongoose';
+
+import { createProduct } from '../controllers/productsController.js';
+import Product from '../models/productModel.js';
+import Store from '../models/storeModel.js';
+
+// Helper to mock response object
+function createRes() {
+  return {
+    statusCode: 0,
+    body: null,
+    status(code) {
+      this.statusCode = code;
+      return this;
+    },
+    json(obj) {
+      this.body = obj;
+    },
+  };
+}
+
+test('createProduct generates sequential productId', async () => {
+  const storeId = new mongoose.Types.ObjectId();
+  Store.findById = async () => ({ _id: storeId });
+  Product.findOne = () => ({
+    sort: async () => ({ productId: 'P005' }),
+  });
+  let savedProduct;
+  Product.prototype.save = async function () {
+    savedProduct = this;
+    return this;
+  };
+
+  const req = {
+    body: { name: 'Test', price: 100, quantity: 5 },
+    userId: storeId,
+  };
+  const res = createRes();
+
+  await createProduct(req, res);
+
+  assert.equal(res.statusCode, 201);
+  assert.equal(savedProduct.productId, 'P006');
+  assert.equal(res.body.product.productId, 'P006');
+});
+
+test('createProduct saves product with generated productId', async () => {
+  const storeId = new mongoose.Types.ObjectId();
+  Store.findById = async () => ({ _id: storeId });
+  Product.findOne = () => ({ sort: async () => null });
+  let savedProduct;
+  Product.prototype.save = async function () {
+    savedProduct = this;
+    return this;
+  };
+
+  const req = {
+    body: { name: 'Another', price: 50, quantity: 2 },
+    userId: storeId,
+  };
+  const res = createRes();
+
+  await createProduct(req, res);
+
+  assert.ok(savedProduct.productId);
+  assert.equal(savedProduct.productId, res.body.product.productId);
+});
+


### PR DESCRIPTION
## Summary
- Generate sequential `productId` in `createProduct` controller so validation passes
- Add tests ensuring product creation assigns and persists `productId`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bccbf53154832d98032fb1abb64f9b